### PR TITLE
Create terraform.io documentation for DNS app resource

### DIFF
--- a/website/citrixitm.erb
+++ b/website/citrixitm.erb
@@ -23,7 +23,7 @@
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-resource-citrixitm-dns-app") %>>
               <a href="/docs/providers/citrixitm/r/dns_app.html">citrixitm_dns_app</a>
-            </li> 
+            </li>
           </ul>
         </li>
       </ul>

--- a/website/citrixitm.erb
+++ b/website/citrixitm.erb
@@ -21,7 +21,7 @@
         <li<%= sidebar_current("docs-citrixitm-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-resource-citrixitm-dns-app") %>>
+            <li<%= sidebar_current("docs-citrixitm-resource-dns-app") %>>
               <a href="/docs/providers/citrixitm/r/dns_app.html">citrixitm_dns_app</a>
             </li>
           </ul>

--- a/website/citrixitm.erb
+++ b/website/citrixitm.erb
@@ -10,17 +10,20 @@
           <a href="/docs/providers/citrixitm/index.html">Citrix ITM Provider</a>
         </li>
 
+        <% if false %>
         <li<%= sidebar_current("docs-citrixitm-datasource") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
-            <%# TODO %>
           </ul>
         </li>
+        <% end %>
 
         <li<%= sidebar_current("docs-citrixitm-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
-            <%# TODO %>
+            <li<%= sidebar_current("docs-resource-citrixitm-dns-app") %>>
+              <a href="/docs/providers/citrixitm/r/dns_app.html">citrixitm_dns_app</a>
+            </li> 
           </ul>
         </li>
       </ul>

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Citrix ITM Provider
 
-This provider allows you to manager your [Citrix ITM](https://www.cedexis.com/) infrastructure using Terraform.
+This provider allows you to manage [Citrix ITM](https://www.cedexis.com/) infrastructure using Terraform.
 
 Use the navigation on the left to read about the available resources.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -14,7 +14,7 @@ Use the navigation on the left to read about the available resources.
 
 ## Example Usage
 
-Suppose we have a DNS routing application specified in a file named example.js.
+The following set of files can be used to create and maintain a Citrix ITM application via Terraform.
 
 **example.js**
 
@@ -29,7 +29,17 @@ function onRequest(request, response) {
 }
 ```
 
-The following Terraform configuration can be used to create and maintain a Citrix ITM application using the contents of that file.
+**vars.tf**
+
+```hcl
+variable "itm_client_id" {
+    description = "Client ID for the Citrix ITM API"
+}
+
+variable "itm_client_secret" {
+    description = "Client secret for the Citrix ITM API"
+}
+```
 
 **main.tf**
 
@@ -44,9 +54,9 @@ provider "citrixitm" {
 }
 
 resource "citrixitm_dns_app" "website" {
-    name             = "Simple Round Robin"
-    description      = "DNS routing for the website"
-    app_data         = "${file("${path.module}/website.dns.js")}"
+    name             = "My App"
+    description      = "A very simple DNS routing app"
+    app_data         = "${file("${path.module}/example.js")}"
     fallback_cname   = "origin.example.com"
 }
 ```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,4 +8,45 @@ description: |-
 
 # Citrix ITM Provider
 
-**TODO**
+This provider allows you to manager your [Citrix ITM](https://www.cedexis.com/) infrastructure using Terraform.
+
+Use the navigation on the left to read about the available resources.
+
+## Example Usage
+
+Suppose we have a DNS routing application specified in a file named example.js.
+
+**example.js**
+
+```javascript
+function init(config) {
+    config.requestProvider('edgecast');
+}
+
+function onRequest(request, response) {
+    response.respond('edgecast', 'www.example.edgecastcdn.net');
+    response.setTTL(600);
+}
+```
+
+The following Terraform configuration can be used to create and maintain a Citrix ITM application using the contents of that file.
+
+**main.tf**
+
+```hcl
+terraform {
+    required_version = ">= 0.11, < 0.12"
+}
+
+provider "citrixitm" {
+    client_id     = "${var.itm_client_id}"
+    client_secret = "${var.itm_client_secret}"
+}
+
+resource "citrixitm_dns_app" "website" {
+    name             = "Simple Round Robin"
+    description      = "DNS routing for the website"
+    app_data         = "${file("${path.module}/website.dns.js")}"
+    fallback_cname   = "origin.example.com"
+}
+```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -60,3 +60,17 @@ resource "citrixitm_dns_app" "website" {
     fallback_cname   = "origin.example.com"
 }
 ```
+
+## Authentication
+
+Terraform requires authentication to use the Citrix ITM API. You will need to set up a client ID and secret pair using the Citrix ITM Portal [OAuth Configuration page](https://portal.cedexis.com/ui/api/oauth). Be sure to keep these credentials secure.
+
+## Configuration Reference
+
+The Citrix ITM provider is configured by setting attributes in the provider block.
+
+The following attributes are supported:
+
+* `client_id` - (Required) The client ID to be used for authenticating with the API.
+
+* `client_secret` - (Required) The client secret corresponding to the client ID.

--- a/website/docs/r/dns_app.html.markdown
+++ b/website/docs/r/dns_app.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "citrixitm"
+page_title: "Citrix ITM: citrixitm_dns_app"
+sidebar_current: "docs-resource-citrixitm-dns-app"
+description: |-
+  Manages a Citrix ITM DNS app resource.
+---
+
+# citrixitm_dns_app
+
+The `citrixitm_dns_app` resource type is used to create and maintain a custom Citrix ITM DNS app. You can read more about custom DNS apps at [Custom JavaScript Apps](https://docs.citrix.com/en-us/citrix-intelligent-traffic-management/openmix.html#custom-javascript-apps).
+
+## Example Usage
+
+```hcl
+resource "citrixitm_dns_app" "my_app" {
+  name = "My App"
+  description = "An example JavaScript DNS routing app"
+  app_data = <<EOF
+function init(config) {
+  config.requestProvider('edgecast');
+}
+
+function onRequest(request, response) {
+  response.respond('edgecast', 'www.example.edgecastcdn.net');
+  response.setTTL(600);
+}
+EOF
+  fallback_cname = "fallback.example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* app_data - (Required) A string containing the JavaScript code defining the app's behavior.
+
+* description - (Optional) A description for the app.
+
+* fallback_cname - (Required) The CNAME that the framework should respond with in the event of a problem.
+
+* fallback_ttl - (Optional) The TTL that should be specified when the framework issues a fallback response. The default is 20.
+
+* name - (Required) A descriptive name for the app.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* cname - The CNAME used to reach the app. This is determined automatically when the app is created.
+
+* version - The version number of the app. This is automatically incremented when the app is updated.
+
+## Import
+
+Terraform `import` functionality is not currently supported.
+

--- a/website/docs/r/dns_app.html.markdown
+++ b/website/docs/r/dns_app.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "citrixitm"
 page_title: "Citrix ITM: citrixitm_dns_app"
-sidebar_current: "docs-resource-citrixitm-dns-app"
+sidebar_current: "docs-citrixitm-resource-dns-app"
 description: |-
   Manages a Citrix ITM DNS app resource.
 ---


### PR DESCRIPTION
This PR adds website documentation for the `citrixitm_dns_app` resource. The failed Travis CI builds are expected. They can't pass until the provider is actually incorporated into the Terraform website repo. 