### PR TITLE
Override user agent string on API requests

### DIFF
--- a/citrixitm/config.go
+++ b/citrixitm/config.go
@@ -9,6 +9,13 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+const (
+	libraryName     = "terraform-provider-citrixitm"
+	libraryVersion  = "0.1.0"
+	libraryURL      = "https://github.com/cedexis/" + libraryName
+	userAgentString = libraryName + "/" + libraryVersion + " (" + libraryURL + ")"
+)
+
 type config struct {
 	ClientID     string
 	ClientSecret string
@@ -40,6 +47,7 @@ func (c *config) Client() (*itm.Client, error) {
 	client, err := itm.NewClient(
 		itm.HTTPClient(oauthConfig.Client(oauth2.NoContext)),
 		itm.BaseURL(c.BaseURL))
+	client.UserAgentString = userAgentString
 	if err != nil {
 		return nil, err
 	}

--- a/citrixitm/config_test.go
+++ b/citrixitm/config_test.go
@@ -1,6 +1,7 @@
 package citrixitm
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 )
@@ -25,5 +26,15 @@ func TestConfig(t *testing.T) {
 		if current.expectedBaseURL != c.BaseURL.String() {
 			t.Error(unexpectedValueString("Base URL", current.expectedBaseURL, c.BaseURL.String()))
 		}
+	}
+}
+
+func TestUserAgentStringOverride(t *testing.T) {
+	baseURL, _ := url.Parse("http://example.com/foo")
+	c := newConfig("some id", "some secret", baseURL)
+	client, _ := c.Client()
+	expectedUserAgentString := fmt.Sprintf("%s/%s (%s)", libraryName, libraryVersion, libraryURL)
+	if client.UserAgentString != expectedUserAgentString {
+		t.Error(unexpectedValueString("User Agent String", expectedUserAgentString, client.UserAgentString))
 	}
 }


### PR DESCRIPTION
This causes the Terraform provider to override the default user agent string of the underlying go-itm library so we can clearly differentiate its requests.