### PR TITLE
Update go-itm dependency to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cedexis/terraform-provider-citrixitm
 require (
 	github.com/apparentlymart/go-cidr v1.0.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/cedexis/go-itm v1.0.0
+	github.com/cedexis/go-itm v1.0.1
 	github.com/hashicorp/go-getter v1.0.2 // indirect
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
 	github.com/hashicorp/go-plugin v0.0.0-20190129155509-362c99b11937 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/cedexis/go-itm v1.0.0 h1:tcnLi0u0xatMsJ74LrNWuFfiyqxShIoq7mas22bpbxs=
 github.com/cedexis/go-itm v1.0.0/go.mod h1:E62ZBgPOgT5r1dHBBPjh2xhL8JXM5glyxG80K8xCJK4=
+github.com/cedexis/go-itm v1.0.1 h1:YMkMHsbfpXCcO7JC4I/va9tKhqhnRg6sUbk8K5JTjRk=
+github.com/cedexis/go-itm v1.0.1/go.mod h1:E62ZBgPOgT5r1dHBBPjh2xhL8JXM5glyxG80K8xCJK4=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This causes API requests from Terraform provider to include the default user agent string of the underlying go-itm library. This can be tested by running the acceptance test suite against the production portal instance and then checking Sumo with the following query (supply your own CID):

```
_source=portal-requests and "NON_INTERACTIVE" and "CID:01-55446"
```

You should be able to observe the user agent string "go-itm/1.0.1 (https://github.com/cedexis/go-itm)" being sent on requests for any of the explicitly made requests from the provider (e.g. `GET /	/api/v2/config/applications/dns.json/46`). Token requests are made implicitly and have Golang's default user agent string. I haven't learned how to override that yet.

Acceptance test suite is run by executing:

```bash
ITM_CLIENT_ID=<your client id> ITM_CLIENT_SECRET=<your client secret> ITM_BASE_URL=https://portal.cedexis.com/api make -s -C $(REPO_DIR) testacc
```