### PR TITLE
Update documentation to clarify support for DNS app import

### DIFF
--- a/examples/dns/import-custom-app/README.md
+++ b/examples/dns/import-custom-app/README.md
@@ -87,7 +87,7 @@ commands will detect it and remind you to do so if necessary.
 To link the existing production app and the Terraform resource configuration, run:
 
 ```bash
-terraform import -var itm_client_id=$CITRIXITM_CLIENT_ID -var itm_client_secret=$CITRIXITM_CLIENT_SECRET citrixitm_dns_app.dns_simple <app_id>
+terraform import -var itm_client_id=$CITRIXITM_CLIENT_ID -var itm_client_secret=$CITRIXITM_CLIENT_SECRET citrixitm_dns_app.simple_app <app_id>
 ```
 
 Replace `<app_id>` with the application ID you noted earlier.

--- a/website/docs/r/dns_app.html.markdown
+++ b/website/docs/r/dns_app.html.markdown
@@ -54,5 +54,18 @@ The following attributes are exported:
 
 ## Import
 
-Terraform `import` functionality is not currently supported.
+An existing Citrix ITM DNS app instance may be imported using its app ID, which is found in the Citrix ITM Portal. For example, say you have an existing app with ID 123, and a Terraform configuration like the following:
 
+```hcl
+resource "citrixitm_dns_app" "my_app" {
+    // settings...
+}
+```
+
+The following command can be used to create an association between the existing app and the Terraform configuration.
+
+```bash
+$ terraform import citrixitm_dns_app.my_app 123
+```
+
+At this point the configuration may or may not match the production state, so you should also run `terraform plan` to see if any changes need to be made to the resource configuration in order to reconcile the differences.

--- a/website/docs/r/dns_app.html.markdown
+++ b/website/docs/r/dns_app.html.markdown
@@ -68,4 +68,4 @@ The following command can be used to create an association between the existing 
 $ terraform import citrixitm_dns_app.my_app 123
 ```
 
-At this point the configuration may or may not match the production state, so you should also run `terraform plan` to see if any changes need to be made to the resource configuration in order to reconcile the differences.
+At this point the resource configuration may or may not match production state, so you should also run `terraform plan` to see if any changes need to be made in order to reconcile the differences.


### PR DESCRIPTION
Originally `terraform import` wasn't supported, but later it was added and I forgot to mention it in the website docs.

This is only a documentation change, so you should be able to just read the updated Markdown file directly. But if you're interested in testing the import functionality itself, this is how I do it:

1. Start up the Docker container (e.g. `make docker-build`, `make docker-run`)
2. On the Docker host in another shell, run `make docker-exec-install-plugin`
3. Navigate to /terraform-provider-citrixitm/examples/dns/import-custom-app
4. Create an app in the Portal using the app.js file from that directory on the Docker host.
5. Obtain the App ID from the Portal and use it to import the app via Terraform. In my case, the app id was 166:

```bash
[container] /terraform-provider-citrixitm/examples/dns/import-custom-app $ terraform import -var itm_client_id=$ITM_CLIENT_ID -var itm_client_secret=$ITM_CLIENT_SECRET citrixitm_dns_app.simple_app 166
```

6. Run a `terraform plan -var itm_client_id=$ITM_CLIENT_ID -var itm_client_secret=$ITM_CLIENT_SECRET` to see if there are any differences between the resource configuration and the Production app. In my case there were because I made no attempt to make the app in the Portal have the correct name, description or fallback CNAME.

```bash
[container] /terraform-provider-citrixitm/examples/dns/import-custom-app $ terraform plan -var itm_client_id=$ITM_CLIENT_ID -var itm_client_secret=$ITM_CLIENT_SECRET 
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

citrixitm_dns_app.simple_app: Refreshing state... (ID: 166)

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ citrixitm_dns_app.simple_app
      description:    "" => "A simple static response app"
      fallback_cname: "foo.example.com" => "origin.example.com"
      name:           "Test Import" => "My Static App"


Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```

7. I want ahead and ran applied the changes, although this isn't really necessary to test the import functionality:

```bash
container] /terraform-provider-citrixitm/examples/dns/import-custom-app $ terraform apply -var itm_client_id=$ITM_CLIENT_ID -var itm_client_secret=$ITM_CLIENT_SECRET 
citrixitm_dns_app.simple_app: Refreshing state... (ID: 166)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ citrixitm_dns_app.simple_app
      description:    "" => "A simple static response app"
      fallback_cname: "foo.example.com" => "origin.example.com"
      name:           "Test Import" => "My Static App"


Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

citrixitm_dns_app.simple_app: Modifying... (ID: 166)
  description:    "" => "A simple static response app"
  fallback_cname: "foo.example.com" => "origin.example.com"
  name:           "Test Import" => "My Static App"
citrixitm_dns_app.simple_app: Modifications complete after 1s (ID: 166)

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

dns_app_cname = 2-01-d896-00a6.cdx.cedexis.net
dns_app_id = 166
dns_app_version = 2
```